### PR TITLE
CORS 설정

### DIFF
--- a/src/main/java/io/jeidiiy/sirenordersystem/config/SecurityConfig.java
+++ b/src/main/java/io/jeidiiy/sirenordersystem/config/SecurityConfig.java
@@ -9,6 +9,7 @@ import io.jeidiiy.sirenordersystem.jwt.service.JwtLogoutSuccessHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -16,6 +17,11 @@ import org.springframework.security.config.annotation.web.configurers.CsrfConfig
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @EnableWebSecurity
@@ -48,11 +54,24 @@ public class SecurityConfig {
         .sessionManagement(
             session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .csrf(CsrfConfigurer::disable)
+        .cors(Customizer.withDefaults())
         .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
         .exceptionHandling(
             exceptionHandler ->
                 exceptionHandler.authenticationEntryPoint(jwtAuthenticationEntryPoint))
         .logout(logout -> logout.logoutSuccessHandler(jwtLogoutSuccessHandler))
         .build();
+  }
+
+  @Bean
+  public CorsConfigurationSource corsConfigurationSource() {
+    CorsConfiguration corsConfiguration = new CorsConfiguration();
+    corsConfiguration.setAllowedOrigins(List.of("http://localhost:3000", "http://127.0.0.1:3000"));
+    corsConfiguration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE"));
+    corsConfiguration.setAllowedHeaders(List.of("*"));
+    corsConfiguration.addExposedHeader("Authorization");
+    var source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/api/v1/**", corsConfiguration);
+    return source;
   }
 }


### PR DESCRIPTION
이 PR은 프론트엔드에서 API 요청 시 발생하는 CORS 오류 해결을 위해 서버에서 CORS 관련 설정을 했다.

- AccessToken을 Authorization 필드로 응답에 담아 보내는데 프론트 단에서 조회할 수 없었다. 이를 ExposeHeader 설정을 통해 노출되도록 했다.