### PR TITLE
유저 정보 조회 API 응답 수정 필요

### DIFF
--- a/src/main/java/io/jeidiiy/sirenordersystem/user/controller/UserController.java
+++ b/src/main/java/io/jeidiiy/sirenordersystem/user/controller/UserController.java
@@ -2,10 +2,7 @@ package io.jeidiiy.sirenordersystem.user.controller;
 
 import io.jeidiiy.sirenordersystem.jwt.model.JwtToken;
 import io.jeidiiy.sirenordersystem.user.domain.User;
-import io.jeidiiy.sirenordersystem.user.domain.dto.UserLoginRequestBody;
-import io.jeidiiy.sirenordersystem.user.domain.dto.UserPasswordPatchRequestBody;
-import io.jeidiiy.sirenordersystem.user.domain.dto.UserPatchRequestBody;
-import io.jeidiiy.sirenordersystem.user.domain.dto.UserPostRequestBody;
+import io.jeidiiy.sirenordersystem.user.domain.dto.*;
 import io.jeidiiy.sirenordersystem.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -41,8 +38,8 @@ public class UserController {
   @Operation(summary = "본인 정보 조회")
   @PreAuthorize("#username == authentication.name")
   @GetMapping("/{username}")
-  public ResponseEntity<User> getUserByUsername(@PathVariable String username) {
-    return ResponseEntity.ok(userService.getUserByUsername(username));
+  public ResponseEntity<UserGetResponseDto> getUserByUsername(@PathVariable String username) {
+    return ResponseEntity.ok(userService.getUserResponseDtoByUsername(username));
   }
 
   @Operation(summary = "본인 정보 수정")

--- a/src/main/java/io/jeidiiy/sirenordersystem/user/domain/dto/UserGetResponseDto.java
+++ b/src/main/java/io/jeidiiy/sirenordersystem/user/domain/dto/UserGetResponseDto.java
@@ -1,0 +1,9 @@
+package io.jeidiiy.sirenordersystem.user.domain.dto;
+
+import io.jeidiiy.sirenordersystem.user.domain.User;
+
+public record UserGetResponseDto(String username, String realname, String nickname) {
+  public static UserGetResponseDto from(User user) {
+    return new UserGetResponseDto(user.getUsername(), user.getRealname(), user.getNickname());
+  }
+}

--- a/src/main/java/io/jeidiiy/sirenordersystem/user/service/UserService.java
+++ b/src/main/java/io/jeidiiy/sirenordersystem/user/service/UserService.java
@@ -99,6 +99,10 @@ public class UserService implements UserDetailsService {
     }
   }
 
+  public UserGetResponseDto getUserResponseDtoByUsername(String username) {
+    return UserGetResponseDto.from(getUserByUsername(username));
+  }
+
   public User getUserByUsername(String username) {
     return userJpaRepository
         .findByUsername(username)

--- a/src/test/java/io/jeidiiy/sirenordersystem/user/controller/UserControllerTest.java
+++ b/src/test/java/io/jeidiiy/sirenordersystem/user/controller/UserControllerTest.java
@@ -58,7 +58,7 @@ class UserControllerTest {
             get("/api/v1/users/{username}", username)
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + jwtToken.accessToken()))
         .andExpect(status().isOk());
-    then(userService).should().getUserByUsername(username);
+    then(userService).should().getUserResponseDtoByUsername(username);
   }
 
   @DisplayName("[GET] 로그인한 유저가 다른 사람 정보 조회 -> 403 Forbidden (실패)")


### PR DESCRIPTION
이 PR은 #54 에 따라 `username`, `nickname`, `realname` 만 내려주도록 API 응답을 변경했다.

This closes #54 