### PR TITLE
JWT 인증 오류 발생 시 예외 처리

### DIFF
--- a/src/main/java/io/jeidiiy/sirenordersystem/config/SecurityConfig.java
+++ b/src/main/java/io/jeidiiy/sirenordersystem/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package io.jeidiiy.sirenordersystem.config;
 import static org.springframework.http.HttpMethod.GET;
 import static org.springframework.http.HttpMethod.POST;
 
+import io.jeidiiy.sirenordersystem.jwt.filter.JwtAuthExceptionFilter;
 import io.jeidiiy.sirenordersystem.jwt.filter.JwtAuthenticationFilter;
 import io.jeidiiy.sirenordersystem.jwt.service.JwtAuthenticationEntryPoint;
 import io.jeidiiy.sirenordersystem.jwt.service.JwtLogoutSuccessHandler;
@@ -16,6 +17,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.intercept.AuthorizationFilter;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -30,6 +32,7 @@ import java.util.List;
 public class SecurityConfig {
 
   private final JwtAuthenticationFilter jwtAuthenticationFilter;
+  private final JwtAuthExceptionFilter jwtAuthExceptionFilter;
   private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
   private final JwtLogoutSuccessHandler jwtLogoutSuccessHandler;
 
@@ -61,6 +64,7 @@ public class SecurityConfig {
         .csrf(CsrfConfigurer::disable)
         .cors(Customizer.withDefaults())
         .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+        .addFilterBefore(jwtAuthExceptionFilter, AuthorizationFilter.class)
         .exceptionHandling(
             exceptionHandler ->
                 exceptionHandler.authenticationEntryPoint(jwtAuthenticationEntryPoint))

--- a/src/main/java/io/jeidiiy/sirenordersystem/exception/ErrorResponse.java
+++ b/src/main/java/io/jeidiiy/sirenordersystem/exception/ErrorResponse.java
@@ -2,6 +2,7 @@ package io.jeidiiy.sirenordersystem.exception;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record ErrorResponse(HttpStatus status, String message) {}
+public record ErrorResponse(HttpStatusCode status, String message) {}

--- a/src/main/java/io/jeidiiy/sirenordersystem/jwt/exception/IlligalSignatureException.java
+++ b/src/main/java/io/jeidiiy/sirenordersystem/jwt/exception/IlligalSignatureException.java
@@ -1,0 +1,9 @@
+package io.jeidiiy.sirenordersystem.jwt.exception;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class IlligalSignatureException extends AuthenticationException {
+  public IlligalSignatureException(String msg) {
+    super(msg);
+  }
+}

--- a/src/main/java/io/jeidiiy/sirenordersystem/jwt/exception/SecurityMalformedJwtException.java
+++ b/src/main/java/io/jeidiiy/sirenordersystem/jwt/exception/SecurityMalformedJwtException.java
@@ -1,0 +1,9 @@
+package io.jeidiiy.sirenordersystem.jwt.exception;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class SecurityMalformedJwtException extends AuthenticationException {
+  public SecurityMalformedJwtException(String msg) {
+    super(msg);
+  }
+}

--- a/src/main/java/io/jeidiiy/sirenordersystem/jwt/exception/SecurityUnsupportedJwtException.java
+++ b/src/main/java/io/jeidiiy/sirenordersystem/jwt/exception/SecurityUnsupportedJwtException.java
@@ -1,0 +1,9 @@
+package io.jeidiiy.sirenordersystem.jwt.exception;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class SecurityUnsupportedJwtException extends AuthenticationException {
+  public SecurityUnsupportedJwtException(String msg) {
+    super(msg);
+  }
+}

--- a/src/main/java/io/jeidiiy/sirenordersystem/jwt/filter/JwtAuthExceptionFilter.java
+++ b/src/main/java/io/jeidiiy/sirenordersystem/jwt/filter/JwtAuthExceptionFilter.java
@@ -1,0 +1,42 @@
+package io.jeidiiy.sirenordersystem.jwt.filter;
+
+import io.jeidiiy.sirenordersystem.jwt.exception.IlligalSignatureException;
+import io.jeidiiy.sirenordersystem.jwt.exception.SecurityMalformedJwtException;
+import io.jeidiiy.sirenordersystem.jwt.exception.SecurityUnsupportedJwtException;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.authentication.CredentialsExpiredException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class JwtAuthExceptionFilter extends OncePerRequestFilter {
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+    Exception ex = (Exception) request.getAttribute("authException");
+    if (ex != null) {
+      if (ex instanceof ExpiredJwtException) {
+        throw new CredentialsExpiredException("만료된 토큰입니다");
+      } else if (ex instanceof UnsupportedJwtException) {
+        throw new SecurityUnsupportedJwtException("지원하지 않는 JWT 형식입니다");
+      } else if (ex instanceof MalformedJwtException) {
+        throw new SecurityMalformedJwtException("잘못된 JWT 구조입니다");
+      } else if (ex instanceof SignatureException) {
+        throw new IlligalSignatureException("잘못된 서명입니다");
+      } else if (ex instanceof UsernameNotFoundException) {
+        throw new UsernameNotFoundException(ex.getMessage());
+      }
+    }
+
+    filterChain.doFilter(request, response);
+  }
+}

--- a/src/main/java/io/jeidiiy/sirenordersystem/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/io/jeidiiy/sirenordersystem/jwt/filter/JwtAuthenticationFilter.java
@@ -1,7 +1,13 @@
 package io.jeidiiy.sirenordersystem.jwt.filter;
 
+import io.jeidiiy.sirenordersystem.jwt.exception.IlligalSignatureException;
 import io.jeidiiy.sirenordersystem.jwt.service.JwtService;
 import io.jeidiiy.sirenordersystem.user.service.UserService;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SignatureException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -9,8 +15,9 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.authentication.*;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.util.ObjectUtils;
@@ -36,14 +43,21 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         && securityContext.getAuthentication() == null
         && !request.getRequestURI().equals("/api/v1/refresh-token")) {
       var accessToken = authorization.substring(BEARER_PREFIX.length()).trim();
-      var username = jwtService.getUsername(accessToken);
-      var userDetails = userService.loadUserByUsername(username);
-      var authenticationToken =
-          new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
-      authenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+      String username;
+      try {
+        username = jwtService.getUsername(accessToken);
+        var userDetails = userService.loadUserByUsername(username);
+        var authenticationToken =
+            new UsernamePasswordAuthenticationToken(
+                userDetails, null, userDetails.getAuthorities());
+        authenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
 
-      securityContext.setAuthentication(authenticationToken);
-      SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+        securityContext.setAuthentication(authenticationToken);
+        SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+      } catch (JwtException | UsernameNotFoundException ex) {
+        // 예외를 request 에 저장 후 나중에 JwtAuthExceptionFilter 에서 처리
+        request.setAttribute("authException", ex);
+      }
     }
     filterChain.doFilter(request, response);
   }

--- a/src/main/java/io/jeidiiy/sirenordersystem/jwt/service/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/io/jeidiiy/sirenordersystem/jwt/service/JwtAuthenticationEntryPoint.java
@@ -2,11 +2,14 @@ package io.jeidiiy.sirenordersystem.jwt.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jeidiiy.sirenordersystem.exception.ErrorResponse;
+import io.jeidiiy.sirenordersystem.jwt.exception.IlligalSignatureException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.security.authentication.CredentialsExpiredException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
@@ -23,10 +26,16 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
       HttpServletResponse response,
       AuthenticationException authException)
       throws IOException {
-    ErrorResponse errorResponse =
-        new ErrorResponse(HttpStatus.UNAUTHORIZED, "JWT 인증에 실패했습니다.");
+    HttpStatusCode statusCode;
+    if (authException instanceof CredentialsExpiredException
+        || authException instanceof IlligalSignatureException) {
+      statusCode = HttpStatus.UNAUTHORIZED;
+    } else {
+      statusCode = HttpStatus.BAD_REQUEST;
+    }
+    ErrorResponse errorResponse = new ErrorResponse(statusCode, authException.getMessage());
     response.setContentType("application/json;charset=UTF-8");
-    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    response.setStatus(statusCode.value());
     response.getWriter().write(mapper.writeValueAsString(errorResponse));
   }
 }

--- a/src/test/java/io/jeidiiy/sirenordersystem/order/controller/OrderControllerTest.java
+++ b/src/test/java/io/jeidiiy/sirenordersystem/order/controller/OrderControllerTest.java
@@ -41,6 +41,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+@DisplayName("[Controller] 주문 컨트롤러 테스트")
 @Import({SecurityConfig.class, JwtService.class})
 @WebMvcTest(OrderController.class)
 class OrderControllerTest {

--- a/src/test/java/io/jeidiiy/sirenordersystem/order/controller/OrderControllerTest.java
+++ b/src/test/java/io/jeidiiy/sirenordersystem/order/controller/OrderControllerTest.java
@@ -41,8 +41,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-@DisplayName("[Controller] 사용자 컨트롤러 테스트")
-@Import({SecurityConfig.class, JwtAuthenticationFilter.class, JwtService.class})
+@Import({SecurityConfig.class, JwtService.class})
 @WebMvcTest(OrderController.class)
 class OrderControllerTest {
   @Autowired MockMvc mvc;

--- a/src/test/java/io/jeidiiy/sirenordersystem/product/controller/ProductControllerTest.java
+++ b/src/test/java/io/jeidiiy/sirenordersystem/product/controller/ProductControllerTest.java
@@ -29,7 +29,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 
 @DisplayName("[Controller] 상품 컨트롤러 테스트")
-@Import({SecurityConfig.class, JwtAuthenticationFilter.class, JwtService.class})
+@Import({SecurityConfig.class, JwtService.class})
 @WebMvcTest(ProductController.class)
 class ProductControllerTest {
   @Autowired MockMvc mvc;

--- a/src/test/java/io/jeidiiy/sirenordersystem/product/controller/TypeControllerTest.java
+++ b/src/test/java/io/jeidiiy/sirenordersystem/product/controller/TypeControllerTest.java
@@ -26,7 +26,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @DisplayName("[Controller] 종류 컨트롤러 테스트")
-@Import({SecurityConfig.class, JwtAuthenticationFilter.class, JwtService.class})
+@Import({SecurityConfig.class, JwtService.class})
 @WebMvcTest(TypeController.class)
 class TypeControllerTest {
   @Autowired MockMvc mvc;

--- a/src/test/java/io/jeidiiy/sirenordersystem/store/controller/StoreControllerTest.java
+++ b/src/test/java/io/jeidiiy/sirenordersystem/store/controller/StoreControllerTest.java
@@ -35,7 +35,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 
 @DisplayName("[Controller] 매장 컨트롤러 테스트")
-@Import({SecurityConfig.class, JwtAuthenticationFilter.class, JwtService.class})
+@Import({SecurityConfig.class, JwtService.class})
 @WebMvcTest(StoreController.class)
 class StoreControllerTest {
   @Autowired MockMvc mvc;

--- a/src/test/java/io/jeidiiy/sirenordersystem/user/controller/UserControllerTest.java
+++ b/src/test/java/io/jeidiiy/sirenordersystem/user/controller/UserControllerTest.java
@@ -34,7 +34,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @DisplayName("[Controller] 사용자 컨트롤러 테스트")
-@Import({SecurityConfig.class, JwtAuthenticationFilter.class, JwtService.class})
+@Import({SecurityConfig.class, JwtService.class})
 @WebMvcTest(UserController.class)
 class UserControllerTest {
   @Autowired MockMvc mvc;


### PR DESCRIPTION
이 PR은 #58 에 따른 기능을 개발하였다.

## 변경사항
###  JWT 인증 예외 처리 필터 적용
Spring Security에서 JWT 인증 과정 중 발생하는 예외를 올바르게 처리하기 위해 예외 처리 필터를 적용하였다.

#### Spring Security의 예외 처리 흐름
- 예외 처리는 `ExceptionTranslationFilter` 이후에서 발생해야 정상적으로 Spring Security 에서 처리된다.
- 기존에는 `FilterSecurityInterceptor` 가 예외 처리를 담당했으나, 최근 버전에서는 `AuthorizationFilter` 가 이를 대신한다.

#### AuthorizationFilter의 기본 예외 처리 방식:

1. `SecurityContext` 에 `Authentication` 객체가 없으면 `AuthenticationCredentialsNotFoundException` 예외 발생.
2. `Authentication` 객체가 있으면 `AuthorizationManager` 에게 전달하여 인가를 검증.
3. 인가되지 않은 경우 `AuthorizationDeniedException` 예외 발생.
4. 발생한 예외는 `ExceptionTranslationFilter` 에서 최종 처리됨.

#### 커스텀 예외 처리 적용 방식
- `ExceptionTranslationFilter` 보다 앞 단계에서 발생한 예외는 Spring Security에서 처리되지 않는다.
- `AuthorizationFilter` 는 기본적인 인증·인가 검증만 수행하므로, 커스텀 예외 처리를 위해 별도의 필터를 추가해야 한다.
- 따라서, `ExceptionTranslationFilter` 와 `AuthorizationFilter` 사이에 커스텀 예외 처리 필터를 삽입하여 예외를 처리하도록 구현하였다.